### PR TITLE
#72 - Opens gallery instead of camera

### DIFF
--- a/library/src/main/java/com/vansuita/pickimage/dialog/PickImageDialog.java
+++ b/library/src/main/java/com/vansuita/pickimage/dialog/PickImageDialog.java
@@ -1,5 +1,6 @@
 package com.vansuita.pickimage.dialog;
 
+import android.Manifest;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
@@ -114,7 +115,7 @@ public class PickImageDialog extends PickImageBaseDialog {
 
             if (granted) {
                 if (!launchSystemDialog()) {
-                    if (grantResults.length == 1) {
+                    if (hasCameraPermission(permissions, grantResults)) {
                         launchGallery();
                     } else {
                         launchCamera();
@@ -129,6 +130,15 @@ public class PickImageDialog extends PickImageBaseDialog {
 
 
         }
+    }
+
+    private boolean hasCameraPermission(String[] permissions, int[] grantResults) {
+        int cameraIndex = 0;
+        while(cameraIndex < permissions.length && !permissions[cameraIndex].equals(Manifest.permission.CAMERA)) {
+            cameraIndex++;
+        }
+
+        return cameraIndex < permissions.length && permissions[cameraIndex].equals(Manifest.permission.CAMERA);
     }
 
 

--- a/library/src/main/java/com/vansuita/pickimage/dialog/PickImageDialog.java
+++ b/library/src/main/java/com/vansuita/pickimage/dialog/PickImageDialog.java
@@ -115,7 +115,16 @@ public class PickImageDialog extends PickImageBaseDialog {
 
             if (granted) {
                 if (!launchSystemDialog()) {
-                    if (hasCameraPermission(permissions, grantResults)) {
+                    // See if the CAMERA permission is among the granted ones
+                    int cameraIndex = -1;
+                    for (int i = 0; i < permissions.length; i++) {
+                        if (permissions[cameraIndex].equals(Manifest.permission.CAMERA)) {
+                            cameraIndex = i;
+                            break;
+                        }
+                    }
+
+                    if (cameraIndex != -1) {
                         launchGallery();
                     } else {
                         launchCamera();
@@ -127,20 +136,8 @@ public class PickImageDialog extends PickImageBaseDialog {
                 if (grantResults.length > 1)
                     Keep.with(getActivity()).askedForPermission();
             }
-
-
         }
     }
-
-    private boolean hasCameraPermission(String[] permissions, int[] grantResults) {
-        int cameraIndex = 0;
-        while(cameraIndex < permissions.length && !permissions[cameraIndex].equals(Manifest.permission.CAMERA)) {
-            cameraIndex++;
-        }
-
-        return cameraIndex < permissions.length && permissions[cameraIndex].equals(Manifest.permission.CAMERA);
-    }
-
 
 
    /* public static void forceDismiss(FragmentManager fm) {


### PR DESCRIPTION
PR for #72 

What I did was determine whether the camera permission was granted by looking into the `permissions[]` array, instead of just looking at the number of permissions granted.

In the bug reproduction instructions, the user tries to open the gallery first, for which s/he grants WRITE_EXTERNAL_STORAGE alone. Then when the user wants to use the camera, CAMERA is granted alone as well, which is what makes the gallery launch instead of the camera.
