### PR TITLE
Fix #76 - Survive "Don't keep Acitvities"

### DIFF
--- a/library/src/main/java/com/vansuita/pickimage/dialog/PickImageBaseDialog.java
+++ b/library/src/main/java/com/vansuita/pickimage/dialog/PickImageBaseDialog.java
@@ -36,6 +36,7 @@ import static com.vansuita.pickimage.R.layout.dialog;
 public abstract class PickImageBaseDialog extends DialogFragment implements IPickClick {
 
     protected static final String SETUP_TAG = "SETUP_TAG";
+    protected static final String RESOLVER_STATE_TAG = "resolverState";
     public static final String DIALOG_FRAGMENT_TAG = PickImageBaseDialog.class.getSimpleName();
 
     private PickSetup setup;
@@ -68,7 +69,7 @@ public abstract class PickImageBaseDialog extends DialogFragment implements IPic
         View view = inflater.inflate(dialog, null, false);
 
         onAttaching();
-        onInitialize();
+        onInitialize(savedInstanceState);
 
         if (isValidProviders()) {
             onBindViewsHolders(view);
@@ -86,6 +87,16 @@ public abstract class PickImageBaseDialog extends DialogFragment implements IPic
         return view;
     }
 
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        Bundle resolverState = new Bundle();
+        this.resolver.onSaveInstanceState(resolverState);
+
+        outState.putBundle(RESOLVER_STATE_TAG, resolverState);
+    }
+
     private void onAttaching() {
         if (onClick == null) {
             if (getActivity() instanceof IPickClick) {
@@ -100,14 +111,16 @@ public abstract class PickImageBaseDialog extends DialogFragment implements IPic
     }
 
 
-    protected void onInitialize() {
+    protected void onInitialize(Bundle savedInstanceState) {
         if (getDialog().getWindow() != null) {
             getDialog().getWindow().requestFeature(Window.FEATURE_NO_TITLE);
             getDialog().getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
         }
 
         this.setup = (PickSetup) getArguments().getSerializable(SETUP_TAG);
-        this.resolver = new IntentResolver(getActivity(), setup);
+
+        Bundle resolverState = savedInstanceState.getBundle(RESOLVER_STATE_TAG);
+        this.resolver = new IntentResolver(getActivity(), setup, resolverState);
     }
 
 

--- a/library/src/main/java/com/vansuita/pickimage/dialog/PickImageBaseDialog.java
+++ b/library/src/main/java/com/vansuita/pickimage/dialog/PickImageBaseDialog.java
@@ -119,7 +119,10 @@ public abstract class PickImageBaseDialog extends DialogFragment implements IPic
 
         this.setup = (PickSetup) getArguments().getSerializable(SETUP_TAG);
 
-        Bundle resolverState = savedInstanceState.getBundle(RESOLVER_STATE_TAG);
+        Bundle resolverState = null;
+        if (savedInstanceState != null) {
+            resolverState = savedInstanceState.getBundle(RESOLVER_STATE_TAG);
+        }
         this.resolver = new IntentResolver(getActivity(), setup, resolverState);
     }
 

--- a/library/src/main/java/com/vansuita/pickimage/resolver/IntentResolver.java
+++ b/library/src/main/java/com/vansuita/pickimage/resolver/IntentResolver.java
@@ -254,14 +254,14 @@ public class IntentResolver {
     private void onRestoreInstanceState(@NonNull Bundle savedInstanceState) {
         final String saveFilePath = savedInstanceState.getString(SAVE_FILE_PATH_TAG);
 
-        if (saveFilePath == null) {
-            throw new NullPointerException();
+        if (saveFilePath != null) {
+            saveFile = new File(saveFilePath);
         }
-
-        saveFile = new File(saveFilePath);
     }
 
     public void onSaveInstanceState(@NonNull Bundle outState) {
-        outState.putString(SAVE_FILE_PATH_TAG, saveFile.getAbsolutePath());
+        if (saveFile != null) {
+            outState.putString(SAVE_FILE_PATH_TAG, saveFile.getAbsolutePath());
+        }
     }
 }

--- a/library/src/main/java/com/vansuita/pickimage/resolver/IntentResolver.java
+++ b/library/src/main/java/com/vansuita/pickimage/resolver/IntentResolver.java
@@ -8,9 +8,11 @@ import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Bundle;
 import android.os.Environment;
 import android.os.Parcelable;
 import android.provider.MediaStore;
+import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
@@ -35,6 +37,8 @@ import java.util.List;
 public class IntentResolver {
 
     public static final int REQUESTER = 99;
+    public static final String SAVE_FILE_PATH_TAG = "savePath";
+
     private Activity activity;
 
     private PickSetup setup;
@@ -42,9 +46,14 @@ public class IntentResolver {
     private Intent cameraIntent;
     private File saveFile;
 
-    public IntentResolver(Activity activity, PickSetup setup) {
+
+    public IntentResolver(Activity activity, PickSetup setup, Bundle savedInstanceState) {
         this.activity = activity;
         this.setup = setup;
+
+        if (savedInstanceState != null) {
+            onRestoreInstanceState(savedInstanceState);
+        }
     }
 
     private Intent loadSystemPackages(Intent intent) {
@@ -240,5 +249,19 @@ public class IntentResolver {
 
     public Activity getActivity() {
         return activity;
+    }
+
+    private void onRestoreInstanceState(@NonNull Bundle savedInstanceState) {
+        final String saveFilePath = savedInstanceState.getString(SAVE_FILE_PATH_TAG);
+
+        if (saveFilePath == null) {
+            throw new NullPointerException();
+        }
+
+        saveFile = new File(saveFilePath);
+    }
+
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        outState.putString(SAVE_FILE_PATH_TAG, saveFile.getAbsolutePath());
     }
 }


### PR DESCRIPTION
PR for #76 
This happened because `saveFile` within `IntentResolver` was lost when the app went to background, since it's inner state was not saved when the containing Activity was destroyed.
My solution was to wrap `IntentResolver` save `saveFile`'s absolute path in a state Bundle, and save that within the dialog's saved instance state bundle.
I wrapped the path in a Bundle because I felt it was cleaner and less prone to key clashes in the future.