### PR TITLE
Changes to how the cancel callback is treated

### DIFF
--- a/library/src/main/java/com/vansuita/pickimage/dialog/PickImageBaseDialog.java
+++ b/library/src/main/java/com/vansuita/pickimage/dialog/PickImageBaseDialog.java
@@ -160,7 +160,9 @@ public abstract class PickImageBaseDialog extends DialogFragment implements IPic
         @Override
         public void onClick(View view) {
             if (view.getId() == R.id.cancel) {
-                onPickCancel.onCancelClick();
+                if (onPickCancel != null) {
+                    onPickCancel.onCancelClick();
+                }
                 dismiss();
             } else {
                 if (view.getId() == R.id.camera) {

--- a/library/src/main/java/com/vansuita/pickimage/dialog/PickImageBaseDialog.java
+++ b/library/src/main/java/com/vansuita/pickimage/dialog/PickImageBaseDialog.java
@@ -97,6 +97,9 @@ public abstract class PickImageBaseDialog extends DialogFragment implements IPic
 
         if (onPickResult == null && getActivity() instanceof IPickResult)
             onPickResult = (IPickResult) getActivity();
+
+        if (onPickCancel == null && getActivity() instanceof IPickCancel)
+            onPickCancel = (IPickCancel) getActivity();
     }
 
 


### PR DESCRIPTION
This PR does two things:
- when no cancel callback was defined and the user clicks on Cancel, prevent the app from crashing
- when no cancel callback was defined and the containing Activity implements IPickCancel, use that