### PR TITLE
Bug Fixed to avoid crash when accepting permission

### DIFF
--- a/library/src/main/java/com/vansuita/pickimage/dialog/PickImageDialog.java
+++ b/library/src/main/java/com/vansuita/pickimage/dialog/PickImageDialog.java
@@ -118,7 +118,7 @@ public class PickImageDialog extends PickImageBaseDialog {
                     // See if the CAMERA permission is among the granted ones
                     int cameraIndex = -1;
                     for (int i = 0; i < permissions.length; i++) {
-                        if (permissions[cameraIndex].equals(Manifest.permission.CAMERA)) {
+                        if (permissions[i].equals(Manifest.permission.CAMERA)) {
                             cameraIndex = i;
                             break;
                         }


### PR DESCRIPTION
IndexOutOfBoundException is handled inside onRequestPermissionsResult in PickImageDialog