### PR TITLE
fixed permissions granted bug

### DIFF
--- a/library/src/main/java/com/vansuita/pickimage/dialog/PickImageDialog.java
+++ b/library/src/main/java/com/vansuita/pickimage/dialog/PickImageDialog.java
@@ -118,8 +118,8 @@ public class PickImageDialog extends PickImageBaseDialog {
                     // See if the CAMERA permission is among the granted ones
                     int cameraIndex = -1;
                     for (int i = 0; i < permissions.length; i++) {
+                        cameraIndex = i;
                         if (permissions[cameraIndex].equals(Manifest.permission.CAMERA)) {
-                            cameraIndex = i;
                             break;
                         }
                     }


### PR DESCRIPTION
Fixed exception that occurs when the user grants camera or gallery permissions.
cameraIndex is equal to -1 on the first loop iteration and ArrayIndexOutOfBoundsException is throwing.   