### PR TITLE
fix: launching gallery instead of camera 

### DIFF
--- a/library/src/main/java/com/vansuita/pickimage/dialog/PickImageDialog.java
+++ b/library/src/main/java/com/vansuita/pickimage/dialog/PickImageDialog.java
@@ -118,14 +118,13 @@ public class PickImageDialog extends PickImageBaseDialog {
                     // See if the CAMERA permission is among the granted ones
                     int cameraIndex = -1;
                     for (int i = 0; i < permissions.length; i++) {
-                        cameraIndex = i;
-                         if (permissions[cameraIndex].equals(Manifest.permission.CAMERA)) {
+                         if (permissions[i].equals(Manifest.permission.CAMERA)) {
                             cameraIndex = i;
                              break;
                          }
                     }
 
-                    if (cameraIndex != -1) {
+                    if (cameraIndex == -1) {
                         launchGallery();
                     } else {
                         launchCamera();


### PR DESCRIPTION
Fix of following issue, when user is asked for permissions before opening camera/gallery
https://github.com/jrvansuita/PickImage/issues/72