### PR TITLE
issue 129 fixed: App crash on gallery app not found fixed

### DIFF
--- a/library/src/main/java/com/vansuita/pickimage/bundle/PickSetup.java
+++ b/library/src/main/java/com/vansuita/pickimage/bundle/PickSetup.java
@@ -52,6 +52,9 @@ public class PickSetup implements Serializable {
 
     private boolean video;
 
+    private String galleryChooserTitle = "";
+    private String cameraChooserTitle = "";
+
     private boolean isCameraToPictures;
 
     @OrientationMode
@@ -290,6 +293,23 @@ public class PickSetup implements Serializable {
     public PickSetup setVideo(boolean video){
         this.video = video;
         return this;
+    }
+
+
+    public String getGalleryChooserTitle() {
+        return galleryChooserTitle;
+    }
+
+    public void setGalleryChooserTitle(String galleryChooserTitle) {
+        this.galleryChooserTitle = galleryChooserTitle;
+    }
+
+    public String getCameraChooserTitle() {
+        return cameraChooserTitle;
+    }
+
+    public void setCameraChooserTitle(String cameraChooserTitle) {
+        this.cameraChooserTitle = cameraChooserTitle;
     }
 
     public PickSetup() {

--- a/library/src/main/java/com/vansuita/pickimage/dialog/PickImageBaseDialog.java
+++ b/library/src/main/java/com/vansuita/pickimage/dialog/PickImageBaseDialog.java
@@ -257,7 +257,7 @@ public abstract class PickImageBaseDialog extends DialogFragment implements IPic
 
     protected void launchGallery() {
         if (resolver.requestGalleryPermissions(this))
-            resolver.launchGallery(this);
+            resolver.launchGallery(this, setup.getGalleryChooserTitle());
     }
 
     protected boolean launchSystemDialog() {

--- a/library/src/main/java/com/vansuita/pickimage/resolver/IntentResolver.java
+++ b/library/src/main/java/com/vansuita/pickimage/resolver/IntentResolver.java
@@ -1,6 +1,7 @@
 package com.vansuita.pickimage.resolver;
 
 import android.Manifest;
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
@@ -12,6 +13,7 @@ import android.os.Environment;
 import android.os.Parcelable;
 import android.provider.MediaStore;
 import android.util.Log;
+import android.widget.Toast;
 
 import com.vansuita.pickimage.R;
 import com.vansuita.pickimage.bundle.PickSetup;
@@ -178,7 +180,11 @@ public class IntentResolver {
     }
 
     public void launchGallery(Fragment listener) {
-        listener.startActivityForResult(loadSystemPackages(getGalleryIntent()), REQUESTER);
+        try {
+            listener.startActivityForResult(loadSystemPackages(getGalleryIntent()), REQUESTER);
+        } catch (ActivityNotFoundException e) {
+            Toast.makeText(listener.getContext(), listener.getContext().getString(R.string.gallery_app_not_found), Toast.LENGTH_SHORT).show();
+        }
     }
 
     public void launchSystemChooser(Fragment listener) {

--- a/library/src/main/java/com/vansuita/pickimage/resolver/IntentResolver.java
+++ b/library/src/main/java/com/vansuita/pickimage/resolver/IntentResolver.java
@@ -100,7 +100,8 @@ public class IntentResolver {
 
             cameraFile().delete();
 
-            listener.startActivityForResult(loadSystemPackages(getCameraIntent()), REQUESTER);
+            Intent chooser = Intent.createChooser(getCameraIntent(), setup.getCameraChooserTitle());
+            listener.startActivityForResult(chooser, REQUESTER);
         }
     }
 
@@ -179,10 +180,11 @@ public class IntentResolver {
         return galleryIntent;
     }
 
-    public void launchGallery(Fragment listener) {
+    public void launchGallery(Fragment listener,String title) {
+        Intent intent = Intent.createChooser(getGalleryIntent(),title);
         try {
-            listener.startActivityForResult(loadSystemPackages(getGalleryIntent()), REQUESTER);
-        } catch (ActivityNotFoundException e) {
+          listener.startActivityForResult(intent, REQUESTER);
+          } catch (ActivityNotFoundException e) {
             Toast.makeText(listener.getContext(), listener.getContext().getString(R.string.gallery_app_not_found), Toast.LENGTH_SHORT).show();
         }
     }

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -8,4 +8,5 @@
     <string name="no_providers">No providers available to show.</string>
     <string name="wrong_authority">FileProvider not declared or has wrong authority. (Must be ${applicationId}.com.vansuita.pickimage.provider, check your AndroidManifest.xml)</string>
     <string name="activity_destroyed">Activity was destroyed, can\'t handle pick image result.</string>
+    <string name="gallery_app_not_found">Gallery app not found.</string>
 </resources>


### PR DESCRIPTION
https://github.com/jrvansuita/PickImage/issues/129

This issue has been fixed in this where the app was crashing in some devices when the Gallery app is not available.