### PR TITLE
If only 1 PickType is given then automatically open the camera/gallery

### DIFF
--- a/library/src/main/java/com/vansuita/pickimage/dialog/PickImageBaseDialog.java
+++ b/library/src/main/java/com/vansuita/pickimage/dialog/PickImageBaseDialog.java
@@ -5,11 +5,13 @@ import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
 import android.os.Handler;
+
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.DialogFragment;
 import androidx.cardview.widget.CardView;
 import androidx.appcompat.widget.LinearLayoutCompat;
+
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -196,50 +198,57 @@ public abstract class PickImageBaseDialog extends DialogFragment implements IPic
 
 
     private void onSetup() {
-        if (setup.getBackgroundColor() != android.R.color.white) {
-            card.setCardBackgroundColor(setup.getBackgroundColor());
+        if (showCamera && !showGallery) {
+            launchCamera();
+        } else if (showGallery && !showCamera) {
+            launchGallery();
+        } else {
+            card.setVisibility(View.VISIBLE);
+            if (setup.getBackgroundColor() != android.R.color.white) {
+                card.setCardBackgroundColor(setup.getBackgroundColor());
 
-            if (showCamera)
-                Util.background(tvCamera, Util.getAdaptiveRippleDrawable(setup.getBackgroundColor()));
+                if (showCamera)
+                    Util.background(tvCamera, Util.getAdaptiveRippleDrawable(setup.getBackgroundColor()));
 
-            if (showGallery)
-                Util.background(tvGallery, Util.getAdaptiveRippleDrawable(setup.getBackgroundColor()));
+                if (showGallery)
+                    Util.background(tvGallery, Util.getAdaptiveRippleDrawable(setup.getBackgroundColor()));
+            }
+
+            tvTitle.setTextColor(setup.getTitleColor());
+
+            if (setup.getButtonTextColor() != 0) {
+                tvCamera.setTextColor(setup.getButtonTextColor());
+                tvGallery.setTextColor(setup.getButtonTextColor());
+            }
+
+            if (setup.getProgressTextColor() != 0)
+                tvProgress.setTextColor(setup.getProgressTextColor());
+
+            if (setup.getCancelTextColor() != 0)
+                tvCancel.setTextColor(setup.getCancelTextColor());
+
+            if (setup.getCameraButtonText() != null)
+                tvCamera.setText(setup.getCameraButtonText());
+
+            if (setup.getGalleryButtonText() != null)
+                tvGallery.setText(setup.getGalleryButtonText());
+
+            tvCancel.setText(setup.getCancelText());
+            tvTitle.setText(setup.getTitle());
+            tvProgress.setText(setup.getProgressText());
+
+            showProgress(false);
+
+            Util.gone(tvCamera, !showCamera);
+            Util.gone(tvGallery, !showGallery);
+
+            llButtons.setOrientation(setup.getButtonOrientation() == LinearLayoutCompat.HORIZONTAL ? LinearLayout.HORIZONTAL : LinearLayout.VERTICAL);
+
+            Util.setIcon(tvCamera, setup.getCameraIcon(), setup.getIconGravity());
+            Util.setIcon(tvGallery, setup.getGalleryIcon(), setup.getIconGravity());
+
+            Util.setDimAmount(setup.getDimAmount(), getDialog());
         }
-
-        tvTitle.setTextColor(setup.getTitleColor());
-
-        if (setup.getButtonTextColor() != 0) {
-            tvCamera.setTextColor(setup.getButtonTextColor());
-            tvGallery.setTextColor(setup.getButtonTextColor());
-        }
-
-        if (setup.getProgressTextColor() != 0)
-            tvProgress.setTextColor(setup.getProgressTextColor());
-
-        if (setup.getCancelTextColor() != 0)
-            tvCancel.setTextColor(setup.getCancelTextColor());
-
-        if (setup.getCameraButtonText() != null)
-            tvCamera.setText(setup.getCameraButtonText());
-
-        if (setup.getGalleryButtonText() != null)
-            tvGallery.setText(setup.getGalleryButtonText());
-
-        tvCancel.setText(setup.getCancelText());
-        tvTitle.setText(setup.getTitle());
-        tvProgress.setText(setup.getProgressText());
-
-        showProgress(false);
-
-        Util.gone(tvCamera, !showCamera);
-        Util.gone(tvGallery, !showGallery);
-
-        llButtons.setOrientation(setup.getButtonOrientation() == LinearLayoutCompat.HORIZONTAL ? LinearLayout.HORIZONTAL : LinearLayout.VERTICAL);
-
-        Util.setIcon(tvCamera, setup.getCameraIcon(), setup.getIconGravity());
-        Util.setIcon(tvGallery, setup.getGalleryIcon(), setup.getIconGravity());
-
-        Util.setDimAmount(setup.getDimAmount(), getDialog());
     }
 
 

--- a/library/src/main/res/layout/dialog.xml
+++ b/library/src/main/res/layout/dialog.xml
@@ -12,6 +12,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="5dp"
+        android:visibility="gone"
         android:layout_gravity="center"
         card_view:cardBackgroundColor="@android:color/white"
         card_view:cardCornerRadius="4dp"


### PR DESCRIPTION
Currently there is no option to automatically open camera/gallery if only 1 PickType is given by user. A dialog is always shown even if only 1 option needs to be shown. This change will show the dialog only if multiple selection options needs to be shown. If only Gallery type is given by the user then it will automatically open gallery app to pick images and if Camera type is given then it will open camera app to capture images. 